### PR TITLE
Switch from fxhash to rustc_hash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ keywords = ["typemap", "extensions", "hashmap"]
 description = "Provides a typemap container with FxHashMap"
 
 [dependencies]
-fxhash = "0.2"
+rustc-hash = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use std::any::{Any, TypeId};
 
-use fxhash::FxHashMap;
+use rustc_hash::FxHashMap;
 
 use std::collections::hash_map;
 use std::marker::PhantomData;
@@ -159,7 +159,7 @@ pub mod concurrent {
 
     use std::any::{Any, TypeId};
 
-    use fxhash::FxHashMap;
+    use rustc_hash::FxHashMap;
 
     use std::collections::hash_map;
     use std::marker::PhantomData;


### PR DESCRIPTION
`rustc_hash` is well maintained, used in Firefox and rustc and the author of `fxhash` recommends it - https://github.com/cbreeden/fxhash/issues/10