### PR TITLE
Freshed dependencies and satiate clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ keywords = ["typemap", "extensions", "hashmap"]
 description = "Provides a typemap container with FxHashMap"
 
 [dependencies]
-rustc-hash = "1"
+rustc-hash = "2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,10 @@ impl KvPair {
 
     pub fn extract<T: 'static>(self) -> Result<T, Self> {
         let KvPair(key, value) = self;
-        value.downcast().map(|boxed| *boxed).map_err(|e| KvPair(key, e))
+        value
+            .downcast()
+            .map(|boxed| *boxed)
+            .map_err(|e| KvPair(key, e))
     }
 }
 
@@ -45,7 +48,11 @@ impl<'a, T: 'static> OccupiedEntry<'a, T> {
 
     /// Sets the value of the entry, and returns the entry's old value.
     pub fn insert(&mut self, value: T) -> T {
-        self.data.insert(Box::new(value)).downcast().map(|boxed| *boxed).unwrap()
+        self.data
+            .insert(Box::new(value))
+            .downcast()
+            .map(|boxed| *boxed)
+            .unwrap()
     }
 
     /// Takes the value out of the entry, and returns it.    
@@ -130,7 +137,10 @@ impl TypeMap {
 
     /// Check if container contains value for type
     pub fn contains<T: 'static>(&self) -> bool {
-        self.map.as_ref().and_then(|m| m.get(&TypeId::of::<T>())).is_some()
+        self.map
+            .as_ref()
+            .and_then(|m| m.get(&TypeId::of::<T>()))
+            .is_some()
     }
 
     /// Get a reference to a value previously inserted on this `TypeMap`.
@@ -167,13 +177,19 @@ impl TypeMap {
 
     /// Get an entry in the `TypeMap` for in-place manipulation.
     pub fn entry<T: 'static>(&mut self) -> Entry<T> {
-        match self.map.get_or_insert_with(|| FxHashMap::default()).entry(TypeId::of::<T>()) {
-            hash_map::Entry::Occupied(e) => {
-                Entry::Occupied(OccupiedEntry { data: e, marker: PhantomData })
-            }
-            hash_map::Entry::Vacant(e) => {
-                Entry::Vacant(VacantEntry { data: e, marker: PhantomData })
-            }
+        match self
+            .map
+            .get_or_insert_with(|| FxHashMap::default())
+            .entry(TypeId::of::<T>())
+        {
+            hash_map::Entry::Occupied(e) => Entry::Occupied(OccupiedEntry {
+                data: e,
+                marker: PhantomData,
+            }),
+            hash_map::Entry::Vacant(e) => Entry::Vacant(VacantEntry {
+                data: e,
+                marker: PhantomData,
+            }),
         }
     }
 }
@@ -199,10 +215,13 @@ pub mod concurrent {
         pub fn extract<T: 'static + Send + Sync>(self) -> Result<T, Self> {
             let KvPair(key, value) = self;
             if value.is::<T>() {
-                Ok((value as Box<dyn Any>).downcast().map(|boxed| *boxed).unwrap())
+                Ok((value as Box<dyn Any>)
+                    .downcast()
+                    .map(|boxed| *boxed)
+                    .unwrap())
             } else {
                 Err(KvPair(key, value))
-            }            
+            }
         }
     }
 
@@ -240,7 +259,10 @@ pub mod concurrent {
 
         /// Takes the value out of the entry, and returns it.    
         pub fn remove(self) -> T {
-            (self.data.remove() as Box<dyn Any>).downcast().map(|boxed| *boxed).unwrap()
+            (self.data.remove() as Box<dyn Any>)
+                .downcast()
+                .map(|boxed| *boxed)
+                .unwrap()
         }
     }
 
@@ -320,7 +342,10 @@ pub mod concurrent {
 
         /// Check if container contains value for type
         pub fn contains<T: 'static>(&self) -> bool {
-            self.map.as_ref().and_then(|m| m.get(&TypeId::of::<T>())).is_some()
+            self.map
+                .as_ref()
+                .and_then(|m| m.get(&TypeId::of::<T>()))
+                .is_some()
         }
 
         /// Get a reference to a value previously inserted on this `TypeMap`.
@@ -357,13 +382,19 @@ pub mod concurrent {
 
         /// Get an entry in the `TypeMap` for in-place manipulation.
         pub fn entry<T: 'static + Send + Sync>(&mut self) -> Entry<T> {
-            match self.map.get_or_insert_with(|| FxHashMap::default()).entry(TypeId::of::<T>()) {
-                hash_map::Entry::Occupied(e) => {
-                    Entry::Occupied(OccupiedEntry { data: e, marker: PhantomData })
-                }
-                hash_map::Entry::Vacant(e) => {
-                    Entry::Vacant(VacantEntry { data: e, marker: PhantomData })
-                }
+            match self
+                .map
+                .get_or_insert_with(|| FxHashMap::default())
+                .entry(TypeId::of::<T>())
+            {
+                hash_map::Entry::Occupied(e) => Entry::Occupied(OccupiedEntry {
+                    data: e,
+                    marker: PhantomData,
+                }),
+                hash_map::Entry::Vacant(e) => Entry::Vacant(VacantEntry {
+                    data: e,
+                    marker: PhantomData,
+                }),
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,7 +424,7 @@ fn test_type_map() {
 
     let entry = map.entry::<MyType2>();
 
-    let mut v = entry.or_insert_with(MyType2::default);
+    let v = entry.or_insert_with(MyType2::default);
 
     v.0 = "Hello".into();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ impl TypeMap {
     /// If a value of this type already exists, it will be returned.
     pub fn insert_kv_pair(&mut self, KvPair(key, value): KvPair) -> Option<KvPair> {
         self.map
-            .get_or_insert_with(|| FxHashMap::default())
+            .get_or_insert_with(FxHashMap::default)
             .insert(key, value)
             .map(|old_value| KvPair(key, old_value))
     }
@@ -130,7 +130,7 @@ impl TypeMap {
     /// If a value of this type already exists, it will be returned.
     pub fn insert<T: 'static>(&mut self, val: T) -> Option<T> {
         self.map
-            .get_or_insert_with(|| FxHashMap::default())
+            .get_or_insert_with(FxHashMap::default)
             .insert(TypeId::of::<T>(), Box::new(val))
             .and_then(|boxed| boxed.downcast().ok().map(|boxed| *boxed))
     }
@@ -179,7 +179,7 @@ impl TypeMap {
     pub fn entry<T: 'static>(&mut self) -> Entry<T> {
         match self
             .map
-            .get_or_insert_with(|| FxHashMap::default())
+            .get_or_insert_with(FxHashMap::default)
             .entry(TypeId::of::<T>())
         {
             hash_map::Entry::Occupied(e) => Entry::Occupied(OccupiedEntry {
@@ -325,7 +325,7 @@ pub mod concurrent {
         /// If a value of this type already exists, it will be returned.
         pub fn insert_kv_pair(&mut self, KvPair(key, value): KvPair) -> Option<KvPair> {
             self.map
-                .get_or_insert_with(|| FxHashMap::default())
+                .get_or_insert_with(FxHashMap::default)
                 .insert(key, value)
                 .map(|old_value| KvPair(key, old_value))
         }
@@ -335,7 +335,7 @@ pub mod concurrent {
         /// If a value of this type already exists, it will be returned.
         pub fn insert<T: Send + Sync + 'static>(&mut self, val: T) -> Option<T> {
             self.map
-                .get_or_insert_with(|| FxHashMap::default())
+                .get_or_insert_with(FxHashMap::default)
                 .insert(TypeId::of::<T>(), Box::new(val))
                 .and_then(|boxed| (boxed as Box<dyn Any>).downcast().ok().map(|boxed| *boxed))
         }
@@ -384,7 +384,7 @@ pub mod concurrent {
         pub fn entry<T: 'static + Send + Sync>(&mut self) -> Entry<T> {
             match self
                 .map
-                .get_or_insert_with(|| FxHashMap::default())
+                .get_or_insert_with(FxHashMap::default)
                 .entry(TypeId::of::<T>())
             {
                 hash_map::Entry::Occupied(e) => Entry::Occupied(OccupiedEntry {


### PR DESCRIPTION
Closes #6 (or would in cunjuction with a tagged release). There are no functional changes here and this doesn't need to be a breaking release, just a patch release is fine. The code changes here are all just formatting and clippy fixes, the dependency bump required no changes.

- **deps: Bump `rustc-hash` to 2.x**
- **style: Reformat with `cargo fmt`**
- **refactor: Remove unused mutable attribute from variable**
- **refactor: Remove redundant closures by just passing functions**
